### PR TITLE
CSV Format Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: Teatime
+
+on: [push, pull_request]
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: [3.6, 3.7, 3.8, pypy3]
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Python dependencies
+              uses: py-actions/py-dependency-install@v2
+              with:
+                  path: "requirements_dev.txt"
+            - name: Run test suite
+              run: make test
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v1
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: ./coverage.xml
+                  fail_ci_if_error: true
+    deploy:
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        needs: test
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: "3.7"
+            - name: Install Python dependencies
+              uses: py-actions/py-dependency-install@v2
+              with:
+                  path: "requirements_dev.txt"
+            - name: Build and publish
+              env:
+                  TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+                  TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+              run: make release

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,13 @@ clean-test: ## remove test and coverage artifacts
 lint: ## check style with flake8
 	flake8 web3data tests
 
+format:
+	isort web3data tests examples
+	black -t py37 web3data tests docs examples
+	docformatter --wrap-descriptions 100 -ri web3data/
+
 test: ## run tests quickly with the default Python
-	pytest
+	pytest -vv --basetemp={envtmpdir} --cov=web3data --cov-report=term --cov-report=xml --cov-report=html --cov-branch
 
 test-all: ## run tests on every Python version with tox
 	tox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,9 +140,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, "web3data", "web3data-py Documentation", [author], 1)
-]
+man_pages = [(master_doc, "web3data", "web3data-py Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------

--- a/tests/test_address_handler.py
+++ b/tests/test_address_handler.py
@@ -38,9 +38,7 @@ ADDRESS_HANDLER_METHODS = (
 
 ADDRESS_PARAMS = []
 for chain_value, call in product(CHAINS, ADDRESS_HANDLER_METHODS):
-    ADDRESS_PARAMS.append(
-        [chain_value] + call[:-1] + [chain_value in call[-1]]
-    )
+    ADDRESS_PARAMS.append([chain_value] + call[:-1] + [chain_value in call[-1]])
 
 
 @pytest.mark.parametrize("chain,method,parameters,raises", ADDRESS_PARAMS)

--- a/tests/test_api_handler.py
+++ b/tests/test_api_handler.py
@@ -55,10 +55,7 @@ def test_allowed_rpc(chain):
         response = handler.rpc("test-method", ["test-param"])
         assert m.call_count == 1
         assert response == TEST_RPC
-        assert (
-            m.request_history[0].url
-            == "https://rpc.web3api.io/?x-api-key=test-key"
-        )
+        assert m.request_history[0].url == "https://rpc.web3api.io/?x-api-key=test-key"
         assert m.request_history[0].method == "POST"
         assert m.request_history[0].json() == {
             "id": 1,

--- a/tests/test_base_handler.py
+++ b/tests/test_base_handler.py
@@ -21,13 +21,9 @@ RESPONSE = {"baz": "qux"}
 
 def assert_request_mock(m):
     assert m.call_count == 1
-    assert (
-        m.request_history[0].url == "http://example.com/test-route?test=value"
-    )
+    assert m.request_history[0].url == "http://example.com/test-route?test=value"
     # assert header kv pairs are in request headers
-    assert set(HEADERS.items()).issubset(
-        set(m.request_history[0].headers.items())
-    )
+    assert set(HEADERS.items()).issubset(set(m.request_history[0].headers.items()))
 
 
 @pytest.mark.parametrize("chain", CHAINS)
@@ -37,9 +33,7 @@ def test_base_handler_empty_response(chain):
         m.register_uri(requests_mock.ANY, requests_mock.ANY, text="")
 
         with pytest.raises(EmptyResponseError):
-            handler.raw_query(
-                "http://example.com/", "test-route", HEADERS, PARAMS
-            )
+            handler.raw_query("http://example.com/", "test-route", HEADERS, PARAMS)
 
         assert m.call_count == 1
         assert_request_mock(m)
@@ -52,9 +46,7 @@ def test_base_handler_empty_json_response(chain):
         m.register_uri(requests_mock.ANY, requests_mock.ANY, json={})
 
         with pytest.raises(EmptyResponseError):
-            handler.raw_query(
-                "http://example.com/", "test-route", HEADERS, PARAMS
-            )
+            handler.raw_query("http://example.com/", "test-route", HEADERS, PARAMS)
 
         assert m.call_count == 1
         assert_request_mock(m)
@@ -67,9 +59,7 @@ def test_base_handler_invalid_response(chain):
         m.register_uri(requests_mock.ANY, requests_mock.ANY, text="invalid")
 
         with pytest.raises(APIError):
-            handler.raw_query(
-                "http://example.com/", "test-route", HEADERS, PARAMS
-            )
+            handler.raw_query("http://example.com/", "test-route", HEADERS, PARAMS)
 
         assert m.call_count == 1
         assert_request_mock(m)
@@ -81,9 +71,7 @@ def test_base_handler_valid_response(chain):
     with requests_mock.Mocker() as m:
         m.register_uri(requests_mock.ANY, requests_mock.ANY, json=RESPONSE)
 
-        resp = handler.raw_query(
-            "http://example.com/", "test-route", HEADERS, PARAMS
-        )
+        resp = handler.raw_query("http://example.com/", "test-route", HEADERS, PARAMS)
 
         assert resp == RESPONSE
         assert_request_mock(m)

--- a/tests/test_token_handler.py
+++ b/tests/test_token_handler.py
@@ -20,9 +20,7 @@ SIGNATURE_HANDLER_METHODS = (["details", ("SIGNATURE",), LIMITED_CHAINS],)
 
 SIGNATURE_PARAMS = []
 for chain_value, call in product(CHAINS, SIGNATURE_HANDLER_METHODS):
-    SIGNATURE_PARAMS.append(
-        [chain_value] + call[:2] + [chain_value in call[2]]
-    )
+    SIGNATURE_PARAMS.append([chain_value] + call[:2] + [chain_value in call[2]])
 
 
 @pytest.mark.parametrize("chain,method,parameters,raises", SIGNATURE_PARAMS)

--- a/tests/test_transaction_handler.py
+++ b/tests/test_transaction_handler.py
@@ -28,9 +28,7 @@ TRANSACTION_HANDLER_METHODS = (
 
 TRANSACTION_PARAMS = []
 for chain_value, call in product(CHAINS, TRANSACTION_HANDLER_METHODS):
-    TRANSACTION_PARAMS.append(
-        [chain_value] + call[:2] + [chain_value in call[2]]
-    )
+    TRANSACTION_PARAMS.append([chain_value] + call[:2] + [chain_value in call[2]])
 
 
 @pytest.mark.parametrize("chain,method,parameters,raises", TRANSACTION_PARAMS)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from web3data.exceptions import APIError
 from web3data.handlers.websocket import WebsocketHandler
 
 DATA_RESPONSE = json.dumps(
@@ -30,6 +31,9 @@ SUBSCRIPTION_RESPONSE = json.dumps(
     }
 )
 UNSUBSCRIPTION_RESPONSE = json.dumps({"jsonrpc": "2.0", "id": 1, "result": True})
+UNKNOWN_RESPONSE = json.dumps(
+    {"jsonrpc": "2.0", "id": 1, "result": {"invalid": "datatype"}}
+)
 
 
 def get_handler():

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -29,9 +29,7 @@ SUBSCRIPTION_RESPONSE = json.dumps(
         "result": "242d29d5c0ec9268f51a39aba4ed6a36c757c03c183633568edb0531658a9799",
     }
 )
-UNSUBSCRIPTION_RESPONSE = json.dumps(
-    {"jsonrpc": "2.0", "id": 1, "result": True}
-)
+UNSUBSCRIPTION_RESPONSE = json.dumps({"jsonrpc": "2.0", "id": 1, "result": True})
 
 
 def get_handler():

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -127,6 +127,14 @@ def test_on_message_unsubscription():
     assert handler.expected_ids == set()
 
 
+def test_on_message_unknown():
+    handler = get_handler()
+    assert_handler_initialized(handler)
+
+    with pytest.raises(APIError):
+        handler._on_message(None, UNKNOWN_RESPONSE)
+
+
 def test_on_message_invalid():
     handler = get_handler()
     assert_handler_initialized(handler)

--- a/web3data/exceptions.py
+++ b/web3data/exceptions.py
@@ -4,8 +4,7 @@
 class APIError(Exception):
     """An exception denoting generic API errors.
 
-    This error is raised when the API returns invalid
-    response data, like invalid JSON.
+    This error is raised when the API returns invalid response data, like invalid JSON.
     """
 
     pass
@@ -14,8 +13,8 @@ class APIError(Exception):
 class EmptyResponseError(APIError):
     """An exception denoting an empty API response.
 
-    This error is raised when the API response content
-    is empty, or it contains an empty JSON object.
+    This error is raised when the API response content is empty, or it contains an empty JSON
+    object.
     """
 
     pass

--- a/web3data/handlers/address.py
+++ b/web3data/handlers/address.py
@@ -63,7 +63,6 @@ class AddressHandler(BaseHandler):
         :key page: The page number to return. (int)
         :key size: Number of records per page. (int)
         :return: The API response parsed into a dict
-
         """
         return self._address_query(
             route="", headers=self.initial_headers, params=kwargs
@@ -89,7 +88,8 @@ class AddressHandler(BaseHandler):
         )
 
     def balance_historical(self, address: str, **kwargs) -> Dict:
-        """Retrieves the historical (time series) account balances for the specified address.
+        """Retrieves the historical (time series) account balances for the
+        specified address.
 
         :param address: The address to fetch information for
         :key blockNumber: Filter by account balances at block number (int)
@@ -131,7 +131,8 @@ class AddressHandler(BaseHandler):
         )
 
     def balances_batch(self, addresses: List[str], **kwargs) -> Dict:
-        """Retrieves the latest account and token balances for the specified addresses.
+        """Retrieves the latest account and token balances for the specified
+        addresses.
 
         This is super useful if you want to get an entire portfolio's summary in a single call.
         Get totals for ETH & all token amounts with market prices.
@@ -150,7 +151,8 @@ class AddressHandler(BaseHandler):
         )
 
     def balances(self, address: str, **kwargs) -> Dict:
-        """Retrieves the latest account and token balances for the specified address.
+        """Retrieves the latest account and token balances for the specified
+        address.
 
         :param address: The address to fetch information for
         :key includePrice: Indicates whether or not to include price data with the results.
@@ -187,7 +189,8 @@ class AddressHandler(BaseHandler):
         )
 
     def internal_messages(self, address: str, **kwargs) -> Dict:
-        """Retrieves internal messages where this address is either the originator or a recipient.
+        """Retrieves internal messages where this address is either the
+        originator or a recipient.
 
         :param address: The address to fetch information for
         :key blockNumber: Filter by internal messages contained within this block number (int)
@@ -212,7 +215,8 @@ class AddressHandler(BaseHandler):
         )
 
     def logs(self, address: str, **kwargs) -> Dict:
-        """Retrieves the logs for the transactions where this address is either the originator or a recipient.
+        """Retrieves the logs for the transactions where this address is either
+        the originator or a recipient.
 
         :param address: The address to fetch information for
         :key blockNumber: Filter by logs contained in this block number (int)
@@ -233,7 +237,8 @@ class AddressHandler(BaseHandler):
         )
 
     def metadata(self, address: str, **kwargs) -> Dict:
-        """Retrieves statistics about the specified address: balances, holdings, etc.
+        """Retrieves statistics about the specified address: balances,
+        holdings, etc.
 
         :param address: The address to fetch information for
         :key timeFormat: The time format to use for the timestamps (milliseconds, ms, iso, iso8611). (str)
@@ -270,7 +275,8 @@ class AddressHandler(BaseHandler):
         )
 
     def token_balances_historical(self, address: str, **kwargs) -> Dict:
-        """Retrieves the historical (time series) token balances for the specified address.
+        """Retrieves the historical (time series) token balances for the
+        specified address.
 
         :param address: The address to fetch information for
         :key amount: Filters by token balances which value is equal to this amount (int)
@@ -350,7 +356,8 @@ class AddressHandler(BaseHandler):
         )
 
     def transactions(self, address: str, **kwargs) -> Dict:
-        """Retrieves the transactions where this address was either the originator or a recipient.
+        """Retrieves the transactions where this address was either the
+        originator or a recipient.
 
         :param address: The address to fetch information for
         :key blockNumber: Filter by transactions for this block number. (int)
@@ -401,7 +408,8 @@ class AddressHandler(BaseHandler):
         )
 
     def metrics(self) -> Dict:
-        """Get metrics for all addresses that have exist publicly for a given blockchain.
+        """Get metrics for all addresses that have exist publicly for a given
+        blockchain.
 
         Default metrics are for Ethereum over a 24h period.
 

--- a/web3data/handlers/base.py
+++ b/web3data/handlers/base.py
@@ -1,7 +1,7 @@
 """This module contains the API handler's base class."""
 
 from json.decoder import JSONDecodeError
-from typing import Any, Dict
+from typing import Dict, Union
 
 import requests
 from requests.compat import urljoin
@@ -39,7 +39,7 @@ class BaseHandler:
         route: str,
         headers: Dict[str, str],
         params: Dict[str, str],
-    ) -> Dict:
+    ) -> Union[Dict, str]:
         """Perform an HTTP GET request on an API REST endpoint.
 
         :param base_url: The API base URL (common prefix)
@@ -51,9 +51,13 @@ class BaseHandler:
         resp = requests.get(
             url=urljoin(base_url, route), headers=headers, params=params
         )
+
         if not resp.content:
             # triggered if the API returns empty response body
             raise EmptyResponseError("The API returned an empty JSON response")
+
+        if params.get("format", "") == "csv":
+            return resp.text
 
         try:
             result = resp.json()

--- a/web3data/handlers/base.py
+++ b/web3data/handlers/base.py
@@ -13,9 +13,8 @@ from web3data.exceptions import APIError, EmptyResponseError
 class BaseHandler:
     """The API handler base class.
 
-    This class defines the basic methods of performing REST API
-    endpoint queries as well as RPC queries, which are implemented
-    across all handler classes to standardize API requests.
+    This class defines the basic methods of performing REST API endpoint queries as well as RPC
+    queries, which are implemented across all handler classes to standardize API requests.
     """
 
     LIMITED = (
@@ -63,9 +62,7 @@ class BaseHandler:
             result = resp.json()
         except JSONDecodeError:
             # triggered e.g. when API returns empty response or XML error message
-            raise APIError(
-                f"Unable to parse API response to JSON: {resp.content}"
-            )
+            raise APIError(f"Unable to parse API response to JSON: {resp.content}")
         if not result:
             # triggered if the API returns empty JSON object response
             raise EmptyResponseError("The API returned an empty JSON response")

--- a/web3data/handlers/block.py
+++ b/web3data/handlers/block.py
@@ -70,12 +70,11 @@ class BlockHandler(BaseHandler):
             none, basic, full. Default: none. (str)
         :return: The API response parsed into a dict
         """
-        return self._block_query(
-            route="", headers=self.initial_headers, params=kwargs
-        )
+        return self._block_query(route="", headers=self.initial_headers, params=kwargs)
 
     def functions(self, block_id: str, **kwargs) -> Dict:
-        """Retrieves all the functions which were called at the specified block number or hash.
+        """Retrieves all the functions which were called at the specified block
+        number or hash.
 
         :param block_id: The block's ID to fetch information for
         :key validationMethod: The validation method to be added to the response:
@@ -110,7 +109,8 @@ class BlockHandler(BaseHandler):
         )
 
     def token_transfers(self, block_id: str, **kwargs) -> Dict:
-        """Retrieves all the token which were transferred at the specified block number.
+        """Retrieves all the token which were transferred at the specified
+        block number.
 
         :param block_id: The block's ID to fetch information for
         :key amount: Filter by tokens transfers where the number of tokens is equal

--- a/web3data/handlers/contract.py
+++ b/web3data/handlers/contract.py
@@ -45,7 +45,8 @@ class ContractHandler(BaseHandler):
         )
 
     def audit(self, address: str, **kwargs) -> Dict:
-        """Retrieves the vulnerabilities audit for the specified contract (if available).
+        """Retrieves the vulnerabilities audit for the specified contract (if
+        available).
 
         The automated security checks are provided by MythX. Check out their
         stellar service over at https://mythx.io/.
@@ -64,7 +65,8 @@ class ContractHandler(BaseHandler):
         )
 
     def details(self, address: str, **kwargs) -> Dict:
-        """Retrieves all the detailed information for the specified contract (ABI, bytecode, sourcecode...).
+        """Retrieves all the detailed information for the specified contract
+        (ABI, bytecode, sourcecode...).
 
         :param address: The address to fetch information for
         :param kwargs: Additional query parameter options

--- a/web3data/handlers/market.py
+++ b/web3data/handlers/market.py
@@ -55,8 +55,9 @@ class MarketHandler(BaseHandler):
         )
 
     def pairs(self, **kwargs) -> Dict:
-        """Retrieves information about supported exchange-pairs.
-        These types of data are supported:
+        """Retrieves information about supported exchange-pairs. These types of
+        data are supported:
+
         - ticker
         - ohlc (open-high-low-close)
         - trade
@@ -137,7 +138,8 @@ class MarketHandler(BaseHandler):
         )
 
     def order_best_bid_historical(self, pair: str, **kwargs) -> Dict:
-        """Retrieves historical best bid and offer information for the specified pair.
+        """Retrieves historical best bid and offer information for the
+        specified pair.
 
         :param pair: The asset pair to look up
         :key exchange: The exchange(s) for which to retrieve order book data.
@@ -156,7 +158,8 @@ class MarketHandler(BaseHandler):
         )
 
     def order_best_bid_latest(self, pair: str, **kwargs) -> Dict:
-        """Retrieves the latest best bid and offer information for the specified pair and exchange.
+        """Retrieves the latest best bid and offer information for the
+        specified pair and exchange.
 
         :param pair: The asset pair to look up
         :key exchange: The exchange(s) for which to retrieve order book data.
@@ -216,7 +219,8 @@ class MarketHandler(BaseHandler):
         )
 
     def uniswap_liquidity(self, pair: str, **kwargs) -> Dict:
-        """Retrieves the Uniswap-specific ether and token balance pairs over time.
+        """Retrieves the Uniswap-specific ether and token balance pairs over
+        time.
 
         Note: This endpoint returns a max of 6 months of historical data. In order
         to get more than 6 months you must use the startDate & endDate parameters
@@ -237,7 +241,8 @@ class MarketHandler(BaseHandler):
         )
 
     def trade_pairs_historical(self, pair: str, **kwargs) -> Dict:
-        """Retrieves the historical (time series) trade data for the specified pair.
+        """Retrieves the historical (time series) trade data for the specified
+        pair.
 
         Note: This endpoint returns a max of 6 months of historical data. In order to
         get more than 6 months you must use the startDate & endDate parameters to move
@@ -272,7 +277,8 @@ class MarketHandler(BaseHandler):
         )
 
     def ohlcv_pair_historical(self, pair: str, **kwargs) -> Dict:
-        """Retrieves the historical (time series) open-high-low-close for the specified pair.
+        """Retrieves the historical (time series) open-high-low-close for the
+        specified pair.
 
         Note: This endpoint returns a max of 6 months of historical data. In order to get more
         than 6 months you must use the startDate & endDate parameters to move the time frame
@@ -347,7 +353,8 @@ class MarketHandler(BaseHandler):
         )
 
     def ticker_bid_ask_latest(self, pair: str, **kwargs) -> Dict:
-        """Retrieves the latest market ticker Bid/Ask/Mid/Last for the specified pair.
+        """Retrieves the latest market ticker Bid/Ask/Mid/Last for the
+        specified pair.
 
         :param pair: The asset pair to look up
         :key exchange: The exchange(s) for which to retrieve market tickers. Example: exchange=bitfinex,bitstamp (str)
@@ -361,7 +368,8 @@ class MarketHandler(BaseHandler):
         )
 
     def ticker_bid_ask_historical(self, pair: str, **kwargs) -> Dict:
-        """Retrieves the historical ticker, bid/ask/mid/last, for the specified pair.
+        """Retrieves the historical ticker, bid/ask/mid/last, for the specified
+        pair.
 
         Note: This endpoint returns a max of 6 months of historical data. In order to get more
         than 6 months you must use the startDate & endDate parameters to move the time frame
@@ -407,7 +415,8 @@ class MarketHandler(BaseHandler):
         )
 
     def token_price_latest(self, address: str, **kwargs) -> Dict:
-        """Retrieves the latest price (and other market information) for the specified token.
+        """Retrieves the latest price (and other market information) for the
+        specified token.
 
         :param address: The token's smart contract address
         :key currency: The additional currency (other than ETH and USD)
@@ -422,7 +431,8 @@ class MarketHandler(BaseHandler):
         )
 
     def token_rankings_historical(self, **kwargs) -> Dict:
-        """Retrieves the top ranked tokens by a specific metric, with a lookback window.
+        """Retrieves the top ranked tokens by a specific metric, with a
+        lookback window.
 
         Useful for viewing token trends.
 

--- a/web3data/handlers/token.py
+++ b/web3data/handlers/token.py
@@ -36,7 +36,8 @@ class TokenHandler(BaseHandler):
         )
 
     def holders_historical(self, address: str, **kwargs) -> Dict:
-        """Retrieves the historical (time series) token holders for the specified token address.
+        """Retrieves the historical (time series) token holders for the
+        specified token address.
 
         :param address: The token's smart contract address
         :key holderAddresses: A comma separated list of addresses for which the historical
@@ -91,7 +92,8 @@ class TokenHandler(BaseHandler):
         return self._token_query(address, "holders/latest", kwargs)
 
     def supply_historical(self, address: str, **kwargs) -> Dict:
-        """Retrieves the historical token supplies (and derivatives) for the specified address.
+        """Retrieves the historical token supplies (and derivatives) for the
+        specified address.
 
         :param address: The token's smart contract address
         :param kwargs: Additional query parameter options
@@ -109,7 +111,8 @@ class TokenHandler(BaseHandler):
         return self._token_query(address, "supplies/historical", kwargs)
 
     def supply_latest(self, address: str) -> Dict:
-        """Retrieves the latest token supplies (and derivatives) for the specified address.
+        """Retrieves the latest token supplies (and derivatives) for the
+        specified address.
 
         :param address: The token's smart contract address
         :return: The API response parsed into a dict
@@ -165,7 +168,8 @@ class TokenHandler(BaseHandler):
         return self._token_query(address, "velocity", kwargs)
 
     def volume(self, address: str, **kwargs) -> Dict:
-        """Retrieves the historical number of transfers for the specified address.
+        """Retrieves the historical number of transfers for the specified
+        address.
 
         :param address: The token's smart contract address
         :key timeFormat: The time format to use with the timestamps: milliseconds/ms or iso/iso8611 (str)

--- a/web3data/handlers/transaction.py
+++ b/web3data/handlers/transaction.py
@@ -40,7 +40,8 @@ class TransactionHandler(BaseHandler):
         )
 
     def token_transfers(self, tx_hash: str) -> Dict:
-        """Retrieves the token transfers that took place in the specified transaction.
+        """Retrieves the token transfers that took place in the specified
+        transaction.
 
         :param tx_hash: The transaction hash to fetch information for
         :return: The API response parsed into a dict
@@ -112,7 +113,8 @@ class TransactionHandler(BaseHandler):
         )
 
     def metrics(self) -> Dict:
-        """Get metrics for recent confirmed transactions for a given blockchain.
+        """Get metrics for recent confirmed transactions for a given
+        blockchain.
 
         :return: The API response parsed into a dict
         """

--- a/web3data/handlers/websocket.py
+++ b/web3data/handlers/websocket.py
@@ -1,10 +1,12 @@
 """This module implements the websocket handler."""
 
 import json
-from typing import Iterable, Tuple, Union
+from typing import Iterable, Union
 from uuid import uuid4
 
 import websocket
+
+from web3data.exceptions import APIError
 
 
 class WebsocketHandler:
@@ -152,6 +154,8 @@ class WebsocketHandler:
             # handle unsubscription acknowledgement
             internal_id = message.get("id")
             self.expected_ids.remove(internal_id)
+        else:
+            raise APIError(f"Received unknown message: {message}")
 
     def _on_error(self, ws, error):
         """An internal handler for websocket errors.

--- a/web3data/handlers/websocket.py
+++ b/web3data/handlers/websocket.py
@@ -198,9 +198,7 @@ class WebsocketHandler:
         :param ws: The websocket client instance
         """
         for internal_id in self.internal_registry.keys():
-            payload = self.internal_registry.get(internal_id, {}).get(
-                "payload"
-            )
+            payload = self.internal_registry.get(internal_id, {}).get("payload")
             if payload is None:
                 raise ValueError(
                     f"Payload for internal ID {internal_id} does not exist"


### PR DESCRIPTION
This PR will add support for the API's `format=csv` format switch. It can be passed regularly as an argument (`{"format": "csv"}`) and will short-circuit the request parsing. The CSV is returned as a decoded string. This enables usage with the STL's `csv` module as well as Pandas `read_csv`.